### PR TITLE
Issue 48 make readme checker case insensitive

### DIFF
--- a/plugins/readme-checker/README.md
+++ b/plugins/readme-checker/README.md
@@ -11,7 +11,8 @@ This plugin uses the following configuration:
 ```yaml
 sauron.plugins:
     readme-checker:
-        minLength: <minimum readme lenght e.g. '1B', '10KB' - default value 1B>
+        minLength: <minimum readme length e.g. '1B', '10KB' - default value 1B>
+        caseSensitive: <if true only 'README.md' is a valid name - default value false>
 ```
 
 ### Input

--- a/plugins/readme-checker/src/main/java/com/freenow/sauron/plugins/ReadmeChecker.java
+++ b/plugins/readme-checker/src/main/java/com/freenow/sauron/plugins/ReadmeChecker.java
@@ -1,9 +1,9 @@
 package com.freenow.sauron.plugins;
 
 import com.freenow.sauron.model.DataSet;
-import com.freenow.sauron.plugins.SauronExtension;
 import com.freenow.sauron.properties.PluginsConfigurationProperties;
 import java.io.BufferedReader;
+import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -11,6 +11,9 @@ import java.io.InputStreamReader;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.stream.Stream;
 import lombok.extern.slf4j.Slf4j;
 import org.pf4j.Extension;
 import org.springframework.util.unit.DataSize;
@@ -23,6 +26,9 @@ public class ReadmeChecker implements SauronExtension
 
     private static final String CONTENT_CHECK_2 = "The team/tribe/organizational unit responsible for this service and at least one fast and good way how to contact them, e.g. slack channel.";
 
+    private static final String CONFIG_DEFAULT_MIN_SIZE = "1B";
+    private static final boolean CONFIG_DEFAULT_CASE_SENSITIVE = false;
+
 
     @Override
     public DataSet apply(PluginsConfigurationProperties properties, DataSet input)
@@ -31,15 +37,21 @@ public class ReadmeChecker implements SauronExtension
         {
             try
             {
-                String minLength = String.valueOf(properties.getPluginConfigurationProperty("readme-checker", "minLength").orElse("1B"));
+                String minLength = String.valueOf(properties.getPluginConfigurationProperty("readme-checker", "minLength").orElse(CONFIG_DEFAULT_MIN_SIZE));
+                Boolean caseSensitive = Boolean.valueOf(String.valueOf(properties.getPluginConfigurationProperty("readme-checker", "caseSensitive")
+                    .orElse(CONFIG_DEFAULT_CASE_SENSITIVE)));
                 long size = DataSize.parse(minLength).toBytes();
 
-                Path path = Paths.get(repositoryPath, "README.md");
-                boolean missingOrEmptyReadme = !Files.exists(path) || (Files.size(path) < size);
-
+                Optional<String> readmeFilename = getReadmeFilename(Paths.get(repositoryPath), caseSensitive);
+                boolean missingOrEmptyReadme = readmeFilename.isEmpty();
                 if (!missingOrEmptyReadme)
                 {
-                    missingOrEmptyReadme = badFileContent(path);
+                    Path readmeFile = Paths.get(repositoryPath, readmeFilename.get());
+                    missingOrEmptyReadme = (Files.size(readmeFile) < size);
+                    if (!missingOrEmptyReadme)
+                    {
+                        missingOrEmptyReadme = badFileContent(readmeFile);
+                    }
                 }
 
                 input.setAdditionalInformation("missingOrEmptyReadme", missingOrEmptyReadme);
@@ -52,6 +64,20 @@ public class ReadmeChecker implements SauronExtension
         });
 
         return input;
+    }
+
+
+    private Optional<String> getReadmeFilename(Path repositoryPath, Boolean caseSensitive)
+    {
+        Stream<String> markdownFiles = Arrays.stream(repositoryPath.toFile().list((dir, name) -> name.contains(".md")));
+        if (caseSensitive)
+        {
+            return markdownFiles.filter(s -> s.equals("README.md")).findFirst();
+        }
+        else
+        {
+            return markdownFiles.filter(s -> s.equalsIgnoreCase("readme.md")).findFirst();
+        }
     }
 
 

--- a/plugins/readme-checker/src/test/java/com/freenow/sauron/plugins/ReadmeCheckerTest.java
+++ b/plugins/readme-checker/src/test/java/com/freenow/sauron/plugins/ReadmeCheckerTest.java
@@ -81,6 +81,13 @@ public class ReadmeCheckerTest
         checkKeyPresent(dataSet, MISSING_OR_EMPTY_README, false);
     }
 
+    @Test
+    public void testReadmeCheckerCaseInsensitive() throws IOException
+    {
+        DataSet dataSet = apply(10, "1B", "readme.md");
+        checkKeyPresent(dataSet, MISSING_OR_EMPTY_README, false);
+    }
+
 
     @Test
     public void testReadmeCheckerReadmeNoConfig() throws IOException
@@ -94,6 +101,14 @@ public class ReadmeCheckerTest
     {
         ReadmeChecker plugin = new ReadmeChecker();
         DataSet dataSet = createDataSet(readmeSize);
+        PluginsConfigurationProperties properties = createPluginConfigurationProperties(minLength);
+        return plugin.apply(properties, dataSet);
+    }
+
+    private DataSet apply(int readmeSize, String minLength, String readmeFileName) throws IOException
+    {
+        ReadmeChecker plugin = new ReadmeChecker();
+        DataSet dataSet = createDataSet(readmeSize, readmeFileName);
         PluginsConfigurationProperties properties = createPluginConfigurationProperties(minLength);
         return plugin.apply(properties, dataSet);
     }
@@ -118,7 +133,7 @@ public class ReadmeCheckerTest
         PluginsConfigurationProperties properties = new PluginsConfigurationProperties();
         if (!StringUtils.isEmpty(minLength))
         {
-            properties.put("readme-checker", new HashMap<String, Object>()
+            properties.put("readme-checker", new HashMap<>()
             {{
                 put("minLength", minLength);
             }});
@@ -127,14 +142,18 @@ public class ReadmeCheckerTest
     }
 
 
-    private DataSet createDataSet(int readmeSize) throws IOException
+    private DataSet createDataSet(int readmeSize) throws IOException {
+        return createDataSet(readmeSize, "README.md");
+    }
+
+    private DataSet createDataSet(int readmeSize, String readmeFileName) throws IOException
     {
         Path repositoryPath = Files.createTempDirectory("readme-checker-test");
         repositoryPath.toFile().deleteOnExit();
 
         if (readmeSize > -1)
         {
-            try (FileOutputStream stream = new FileOutputStream(repositoryPath.resolve("README.md").toFile()))
+            try (FileOutputStream stream = new FileOutputStream(repositoryPath.resolve(readmeFileName).toFile()))
             {
                 stream.write(new byte[readmeSize]);
             }

--- a/plugins/readme-checker/src/test/java/com/freenow/sauron/plugins/ReadmeCheckerTest.java
+++ b/plugins/readme-checker/src/test/java/com/freenow/sauron/plugins/ReadmeCheckerTest.java
@@ -81,11 +81,28 @@ public class ReadmeCheckerTest
         checkKeyPresent(dataSet, MISSING_OR_EMPTY_README, false);
     }
 
+
     @Test
     public void testReadmeCheckerCaseInsensitive() throws IOException
     {
-        DataSet dataSet = apply(10, "1B", "readme.md");
+        DataSet dataSet = apply(10, "1B", "readme.md", false);
         checkKeyPresent(dataSet, MISSING_OR_EMPTY_README, false);
+    }
+
+
+    @Test
+    public void testReadmeCheckerCaseInsensitiveMixedCase() throws IOException
+    {
+        DataSet dataSet = apply(10, "1B", "ReadmE.md", false);
+        checkKeyPresent(dataSet, MISSING_OR_EMPTY_README, false);
+    }
+
+
+    @Test
+    public void testReadmeCheckerCaseSensitivityEnabled() throws IOException
+    {
+        DataSet dataSet = apply(10, "1B", "readme.md", true);
+        checkKeyPresent(dataSet, MISSING_OR_EMPTY_README, true);
     }
 
 
@@ -105,11 +122,21 @@ public class ReadmeCheckerTest
         return plugin.apply(properties, dataSet);
     }
 
+
     private DataSet apply(int readmeSize, String minLength, String readmeFileName) throws IOException
     {
         ReadmeChecker plugin = new ReadmeChecker();
         DataSet dataSet = createDataSet(readmeSize, readmeFileName);
         PluginsConfigurationProperties properties = createPluginConfigurationProperties(minLength);
+        return plugin.apply(properties, dataSet);
+    }
+
+
+    private DataSet apply(int readmeSize, String minLength, String readmeFileName, boolean caseSensitive) throws IOException
+    {
+        ReadmeChecker plugin = new ReadmeChecker();
+        DataSet dataSet = createDataSet(readmeSize, readmeFileName);
+        PluginsConfigurationProperties properties = createPluginConfigurationProperties(minLength, caseSensitive);
         return plugin.apply(properties, dataSet);
     }
 
@@ -130,21 +157,31 @@ public class ReadmeCheckerTest
 
     private PluginsConfigurationProperties createPluginConfigurationProperties(String minLength)
     {
+        return createPluginConfigurationProperties(minLength, true);
+    }
+
+
+    private PluginsConfigurationProperties createPluginConfigurationProperties(String minLength, boolean caseSensitive)
+    {
         PluginsConfigurationProperties properties = new PluginsConfigurationProperties();
+        HashMap<String, Object> readmeCheckerProperties = new HashMap<>();
+
         if (!StringUtils.isEmpty(minLength))
         {
-            properties.put("readme-checker", new HashMap<>()
-            {{
-                put("minLength", minLength);
-            }});
+            readmeCheckerProperties.put("minLength", minLength);
         }
+        readmeCheckerProperties.put("caseSensitive", Boolean.toString(caseSensitive));
+
+        properties.put("readme-checker", readmeCheckerProperties);
         return properties;
     }
 
 
-    private DataSet createDataSet(int readmeSize) throws IOException {
+    private DataSet createDataSet(int readmeSize) throws IOException
+    {
         return createDataSet(readmeSize, "README.md");
     }
+
 
     private DataSet createDataSet(int readmeSize, String readmeFileName) throws IOException
     {


### PR DESCRIPTION
The `readme-checker` plugin is case insensitive by default, but can be configured to be.

Actual Behaviour - Default:

Project with "README.md" will be flagged as `missingOrEmptyReadme = false`
Project with "readme.md" will be flagged as `missingOrEmptyReadme = false`

Actual Behaviour - Case Sensitive:

Project with "README.md" will be flagged as `missingOrEmptyReadme = false`
Project with "readme.md" will be flagged as `missingOrEmptyReadme = true`
Project with "ReadmE.md" will be flagged as `missingOrEmptyReadme = true`