### PR TITLE
Release a Docker image compatible with arm64 

### DIFF
--- a/.github/buildkitd.toml
+++ b/.github/buildkitd.toml
@@ -1,0 +1,2 @@
+[worker.oci]
+  max-parallelism = 2

--- a/.github/workflows/release-components.yml
+++ b/.github/workflows/release-components.yml
@@ -89,6 +89,15 @@ jobs:
         id: extractversion
         run: echo "::set-output name=version::$(cut -c16- <<< "${{ steps.previoustag.outputs.tag }}")"
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          config: .github/buildkitd.toml
+
       - name: Publish to Registry
         if: steps.changes.outputs.src == 'true' && steps.changes.outputs.sauron-service == 'true'
         uses: elgohr/Publish-Docker-Github-Action@v5

--- a/.github/workflows/release-components.yml
+++ b/.github/workflows/release-components.yml
@@ -91,7 +91,7 @@ jobs:
 
       - name: Publish to Registry
         if: steps.changes.outputs.src == 'true' && steps.changes.outputs.sauron-service == 'true'
-        uses: elgohr/Publish-Docker-Github-Action@3.02
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: freenowtech/sauron/sauron-service
           username: ${{ secrets.FREE_NOW_GITHUB_USER }}
@@ -100,3 +100,4 @@ jobs:
           workdir: sauron-service/
           registry: ghcr.io
           tags: "latest,${{ steps.extractversion.outputs.version }}"
+          platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
This change allows releasing a Docker image that is compatible with architectures amd64 and arm64.

The changes in detail:
- Set up workflow to use QEMU. QEMU provides the emulation layer to run Docker on different platforms.
- Set up buildx. buildx handles building images for different platforms. To speed things up, it builds two images in parallel.
- Configure the Docker action to create images for amd64 and arm64.