### PR TITLE
Fix startup error on arm64 architecture

### DIFF
--- a/sauron-service/Dockerfile
+++ b/sauron-service/Dockerfile
@@ -72,9 +72,12 @@ RUN mkdir -p /sauron/plugins
 
 VOLUME /sauron/plugins
 
-ENV TINI_VERSION v0.18.0
+ENV TINI_VERSION v0.19.0
 
-ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /usr/bin/tini
+# Defined by Docker, see https://docs.docker.com/desktop/extensions-sdk/extensions/multi-arch/#adding-multi-arch-binaries
+ARG TARGETARCH
+
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-${TARGETARCH} /usr/bin/tini
 
 RUN chmod a+x /usr/bin/tini
 


### PR DESCRIPTION
A follow-up PR to #152. That PR introduced a regression that prevents sauron-service from starting on nodes with architecture arm64.

The issue is caused by tini, which needs to be installed in a variant compatible with the current architecture.

This change updates tini to 0.19.0, because the project releases multi-platform binaries starting with that version. It also downloads tini using the version compatible with the current architecture.