### PR TITLE
Add support for Go projects

### DIFF
--- a/plugins/dependency-checker/src/main/java/com/freenow/sauron/plugins/ProjectType.java
+++ b/plugins/dependency-checker/src/main/java/com/freenow/sauron/plugins/ProjectType.java
@@ -13,6 +13,7 @@ public enum ProjectType
     PYTHON_POETRY,
     SBT,
     CLOJURE,
+    GO,
     UNKNOWN;
 
 
@@ -49,6 +50,10 @@ public enum ProjectType
         if (Files.exists(repositoryPath.resolve("project.clj")))
         {
             return CLOJURE;
+        }
+        if (Files.exists(repositoryPath.resolve("go.mod")))
+        {
+            return GO;
         }
 
         return UNKNOWN;

--- a/plugins/dependency-checker/src/test/java/com/freenow/sauron/plugins/DependencyCheckerTest.java
+++ b/plugins/dependency-checker/src/test/java/com/freenow/sauron/plugins/DependencyCheckerTest.java
@@ -146,6 +146,14 @@ public class DependencyCheckerTest
         checkKeyPresent(dataSet, "projectType", CLOJURE.toString());
     }
 
+    @Test
+    public void testDependencyCheckerGoProject() throws IOException, URISyntaxException
+    {
+        DataSet dataSet = createDataSet("go.mod", "go.mod");
+        dataSet = plugin.apply(new PluginsConfigurationProperties(), dataSet);
+        checkKeyPresent(dataSet, "projectType", GO.toString());
+    }
+
 
     private void checkKeyPresent(DataSet dataSet, String key, Object expected)
     {

--- a/plugins/dependency-checker/src/test/java/com/freenow/sauron/plugins/DependencyCheckerTest.java
+++ b/plugins/dependency-checker/src/test/java/com/freenow/sauron/plugins/DependencyCheckerTest.java
@@ -146,6 +146,7 @@ public class DependencyCheckerTest
         checkKeyPresent(dataSet, "projectType", CLOJURE.toString());
     }
 
+
     @Test
     public void testDependencyCheckerGoProject() throws IOException, URISyntaxException
     {

--- a/plugins/dependency-checker/src/test/resources/go.mod
+++ b/plugins/dependency-checker/src/test/resources/go.mod
@@ -1,0 +1,3 @@
+module git.example.local/unittest
+
+go 1.21


### PR DESCRIPTION
Before this change, Sauron does not detect Go projects. This can lead to a lot of entries that have `projectType` set to `UNKNOWN`.
The large number of `UNKNOWN` entries that are Go projects makes it harder to find entries for which the detection logic does not work.

This change adds support for detecting Go projects.