### PR TITLE
webhook: Use Maps instead of Lists in configuration

### DIFF
--- a/plugins/webhook/README.md
+++ b/plugins/webhook/README.md
@@ -7,11 +7,12 @@ This plugin sends HTTP requests to third-party endpoints to trigger further proc
 ## Configuration
 
 ```yaml
-- webhook:
-    endpoints:
-      - url: "http://example.localhost/trigger" # URL to send the request to. Required.
-        method: "POST"                          # HTTP method to use. Default is POST.
-        includeDataSet: false                   # Send the Sauron Data Set as the body of the request. Default is false.
+webhook:
+  endpoints:
+    example:
+      url: "http://example.localhost/trigger" # URL to send the request to. Required.
+      method: "POST"                          # HTTP method to use. Default is POST.
+      includeDataSet: false                   # Send the Sauron Data Set as the body of the request. Default is false.
 ```
 
 ## Input

--- a/plugins/webhook/src/test/java/com/freenow/sauron/plugins/WebhookTest.java
+++ b/plugins/webhook/src/test/java/com/freenow/sauron/plugins/WebhookTest.java
@@ -98,7 +98,10 @@ public class WebhookTest
         {{
             put("webhook", new HashMap<>()
             {{
-                put("endpoints", List.of(endpoint));
+                put("endpoints", new HashMap<>()
+                {{
+                    put("unittest", endpoint);
+                }});
             }});
         }};
     }


### PR DESCRIPTION
Fixes an issue where a type-casting a list fails:
```
java.lang.ClassCastException: class java.util.LinkedHashMap cannot be cast to class java.util.List (java.util.LinkedHashMap and java.util.List are in module java.base of loader 'bootstrap')
```