### PR TITLE
Artifactory auth migration to Identity/Access Token.

### DIFF
--- a/sauron-service/src/main/java/com/freenow/sauron/config/ArtifactoryConfig.java
+++ b/sauron-service/src/main/java/com/freenow/sauron/config/ArtifactoryConfig.java
@@ -22,8 +22,7 @@ public class ArtifactoryConfig
     {
         return ArtifactoryClientBuilder.create()
             .setUrl(artifactoryConfigurationProperties.getUrl())
-            .setUsername(artifactoryConfigurationProperties.getUsername())
-            .setPassword(artifactoryConfigurationProperties.getPassword())
+            .setAccessToken(artifactoryConfigurationProperties.getAccessToken())
             .build();
     }
 

--- a/sauron-service/src/main/java/com/freenow/sauron/properties/ArtifactoryConfigurationProperties.java
+++ b/sauron-service/src/main/java/com/freenow/sauron/properties/ArtifactoryConfigurationProperties.java
@@ -11,9 +11,7 @@ public class ArtifactoryConfigurationProperties
 
     private String repository;
 
-    private String username;
-
-    private String password;
+    private String accessToken;
 
     private String groupId;
 


### PR DESCRIPTION
As JFrog has decided to begin deprecating `API Keys` and recommends using `Identity/Access Tokens`, future versions of Artifactory Server will no longer support authentication with API Keys.

[Learn more about generating an Identity Token here](https://jfrog.com/help/r/jfrog-platform-administration-documentation/generate-identity-token).