### PR TITLE
kubernetesapi-report: Support authentication via kube config file

### DIFF
--- a/plugins/kubernetesapi-report/README.md
+++ b/plugins/kubernetesapi-report/README.md
@@ -15,11 +15,11 @@ sauron.plugins:
   kubernetesapi-report:
     serviceLabel: "label/service.name" # The label that will used as a selector to find the resource by serviceName
     # When checks are needed in different clusters:
-    #  - deploy https://hub.docker.com/r/bitnami/kubectl/ as service in the desired cluster
-    #  - set below the url for the cluster     
+    #  - set up a kube config file, see https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/
+    #  - set up an association between the environment name and the name of a context in the kube config file
     apiClientConfig:
       default: "default"
-      clusterName: "cluster-url"
+      environmentName: "kubeConfigContextName"
     selectors:
       pod:
         - label

--- a/plugins/kubernetesapi-report/README.md
+++ b/plugins/kubernetesapi-report/README.md
@@ -15,11 +15,13 @@ sauron.plugins:
   kubernetesapi-report:
     serviceLabel: "label/service.name" # The label that will used as a selector to find the resource by serviceName
     # When checks are needed in different clusters:
-    #  - set up a kube config file, see https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/
-    #  - set up an association between the environment name and the name of a context in the kube config file
+    #  - Set up a kube config file, see https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/.
+    #  - Set up an association between the environment name and the name of a context in the kube config file.
+    #  - Optionally, use kubeConfigFile to set the location of the kube config file. Defaults to "$HOME/.kube/config" if not set.
     apiClientConfig:
       default: "default"
       environmentName: "kubeConfigContextName"
+    kubeConfigFile: "/home/user/.kube/config"
     selectors:
       pod:
         - label

--- a/plugins/kubernetesapi-report/src/main/java/com/freenow/sauron/plugins/APIClientFactory.java
+++ b/plugins/kubernetesapi-report/src/main/java/com/freenow/sauron/plugins/APIClientFactory.java
@@ -3,7 +3,11 @@ package com.freenow.sauron.plugins;
 import com.freenow.sauron.model.DataSet;
 import com.freenow.sauron.properties.PluginsConfigurationProperties;
 import io.kubernetes.client.openapi.ApiClient;
+import io.kubernetes.client.util.ClientBuilder;
 import io.kubernetes.client.util.Config;
+import io.kubernetes.client.util.KubeConfig;
+import java.io.File;
+import java.io.FileReader;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -12,6 +16,9 @@ import lombok.extern.slf4j.Slf4j;
 
 import static com.freenow.sauron.plugins.KubernetesApiReport.API_CLIENT_CONFIG_PROPERTY;
 import static com.freenow.sauron.plugins.KubernetesApiReport.PLUGIN_ID;
+import static io.kubernetes.client.util.KubeConfig.ENV_HOME;
+import static io.kubernetes.client.util.KubeConfig.KUBECONFIG;
+import static io.kubernetes.client.util.KubeConfig.KUBEDIR;
 import static org.apache.commons.lang3.StringUtils.EMPTY;
 
 @Slf4j
@@ -31,28 +38,33 @@ public class APIClientFactory
     }
 
 
+    /**
+     * Creates the Kubernetes API client for an environment.
+     * It reads the environment from the field "environment" in the DataSet.
+     * If no client for the environment can be found, then it falls back to a default client.
+     * <p>
+     * The configuration of this plugin supports multiple ways to create an API client:
+     * <pre>
+     *     kubernetesapi-report:
+     *       # ...
+     *       apiClientConfig:
+     *         default: default # Use the default client
+     *         clusterOne: "https://clusterOne.local" # Use a URL
+     *         clusterTwo: clusterTwo # Use the context "clusterTwo" from the kube config file at $HOME/.kube/config
+     *       # ...
+     * </pre>
+     *
+     * @param input The current DataSet.
+     * @param properties Plugin configuration.
+     * @return Kubernetes API client.
+     */
     public ApiClient get(final DataSet input, final PluginsConfigurationProperties properties)
     {
         if (apiClients.isEmpty())
         {
             properties.getPluginConfigurationProperty(PLUGIN_ID, API_CLIENT_CONFIG_PROPERTY)
                 .ifPresent(config -> ((Map<String, String>) config).forEach((k, v) -> {
-                    if (DEFAULT_CLIENT_CONFIG.equalsIgnoreCase(k))
-                    {
-                        try
-                        {
-                            apiClients.put(DEFAULT_CLIENT_CONFIG, Config.defaultClient());
-                        }
-                        catch (Exception e)
-                        {
-                            log.error("API Client not initialized. Error: {}", e.getMessage(), e);
-                            throw new RuntimeException(e);
-                        }
-                    }
-                    else
-                    {
-                        apiClients.put(k, Config.fromUrl(v));
-                    }
+                    apiClients.put(k, createClient(k, v));
                 }));
 
             if (apiClients.isEmpty())
@@ -69,5 +81,35 @@ public class APIClientFactory
             }
         }
         return Optional.ofNullable(apiClients.get(input.getStringAdditionalInformation(ENVIRONMENT).orElse(EMPTY))).orElse(apiClients.get(DEFAULT_CLIENT_CONFIG));
+    }
+
+    private ApiClient createClient(String cluster, String value)
+    {
+        try
+        {
+            if (DEFAULT_CLIENT_CONFIG.equalsIgnoreCase(cluster))
+            {
+                log.debug("Creating default Kubernetes client for cluster {}", cluster);
+                return Config.defaultClient();
+            }
+
+            if (value.startsWith("https://"))
+            {
+                log.debug("Creating Kubernetes client from URL {} for cluster {}", value, cluster);
+                return Config.fromUrl(value);
+            }
+
+            log.debug("Creating Kubernetes client from config for cluster {}", cluster);
+            // Create KubeConfig here because it allows setting the context.
+            File configFile = new File(new File(System.getenv(ENV_HOME), KUBEDIR), KUBECONFIG);
+            KubeConfig kubeConfig = KubeConfig.loadKubeConfig(new FileReader(configFile));
+            kubeConfig.setContext(value);
+            return ClientBuilder.kubeconfig(kubeConfig).build();
+        }
+        catch (Exception e)
+        {
+            log.error("API Client for {} not initialized. Error: {}", cluster, e.getMessage(), e);
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/plugins/kubernetesapi-report/src/main/java/com/freenow/sauron/plugins/KubernetesApiReport.java
+++ b/plugins/kubernetesapi-report/src/main/java/com/freenow/sauron/plugins/KubernetesApiReport.java
@@ -21,6 +21,7 @@ public class KubernetesApiReport implements SauronExtension
     static final String SELECTORS_PROPERTY = "selectors";
     static final String ENV_VARS_PROPERTY = "environmentVariablesCheck";
     static final String PROPERTIES_FILES_CHECK = "propertiesFilesCheck";
+    static final String KUBE_CONFIG_FILE_PROPERTY = "kubeConfigFile";
 
     private APIClientFactory apiClientFactory = new APIClientFactory();
     private KubernetesLabelAnnotationReader kubernetesLabelAnnotationReader = new KubernetesLabelAnnotationReader();

--- a/plugins/kubernetesapi-report/src/test/resources/kubeConfigFile.yaml
+++ b/plugins/kubernetesapi-report/src/test/resources/kubeConfigFile.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Config
+
+clusters:
+  - cluster:
+      server: https://kubernetes.cluster-c.local
+    name: cluster-c
+
+users:
+  - name: unittest
+
+contexts:
+  - context:
+      cluster: cluster-c
+      user: unittest
+    name: cluster-c


### PR DESCRIPTION
Using `kubectl proxy` isn't a recommended approach because it bypasses authentication.

Authenticate via a kube config file and a context instead.