### PR TITLE
Change Plugins update scheduler to run according to the cron in the configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ Sauron has an embedded plugin system that allows anyone to insert its own busine
 information during the building/deploy process. It uses the [PF4J](https://github.com/pf4j/pf4j) which is a plugin
 framework written in Java, and provides a nice interface to implement an integration in your service.
 
-During the startup Sauron loads all available plugins, and updates them every **5 minutes** using the pre-defined
+During the startup Sauron loads all available plugins, and updates them according to the scheduler configuration using the pre-defined
 plugin repository (Local or Artifactory). For more details please refer to
 [sauron-service.yml](https://github.com/freenowtech/sauron/blob/main/sauron-service/docker/config/sauron-service.yml).
 

--- a/sauron-service/src/main/java/com/freenow/sauron/plugins/AutomaticPluginUpdater.java
+++ b/sauron-service/src/main/java/com/freenow/sauron/plugins/AutomaticPluginUpdater.java
@@ -20,8 +20,6 @@ public class AutomaticPluginUpdater
 
     private final ApplicationEventPublisher applicationEventPublisher;
 
-    private static final long PLUGIN_UPDATE_DELAY_MILLIS = 300000;
-
 
     @Autowired
     public AutomaticPluginUpdater(UpdateManager updateManager, PluginManager pluginManager, ApplicationEventPublisher applicationEventPublisher)
@@ -32,7 +30,7 @@ public class AutomaticPluginUpdater
     }
 
 
-    @Scheduled(fixedDelay = PLUGIN_UPDATE_DELAY_MILLIS)
+    @Scheduled(cron = "${plugin.update.scheduler.cron}")
     public void update()
     {
         PluginsLoadedEvent event = new PluginsLoadedEvent();


### PR DESCRIPTION
This change moves the plugin update scheduler from a hardcoded value to a configurable cron expression, allowing flexibility through configuration settings.