### PR TITLE
Use `npm sbom` in DependencyChecker npm SBOM Generation

### DIFF
--- a/plugins/dependency-checker/README.md
+++ b/plugins/dependency-checker/README.md
@@ -18,7 +18,7 @@ This plugin does not need a configuration.
 
 ### Output
 
-- cycloneDxBomPath: Path to the cycloneDx `bom.xml`
+- cycloneDxBomPath: Path to the cycloneDx `bom.xml` or `bom.json`
 
 - projectType: Project type. Possible values:
    - `MAVEN`

--- a/plugins/dependency-checker/pom.xml
+++ b/plugins/dependency-checker/pom.xml
@@ -37,7 +37,7 @@
         <jackson.version>2.15.0</jackson.version>
         <elasticsearch.version>7.10.2</elasticsearch.version>
         <scm.url>scm:git:git@github.com:freenowtech/sauron.git</scm.url>
-        <cyclonedx-core-java.version>7.3.2</cyclonedx-core-java.version>
+        <cyclonedx-core-java.version>8.0.3</cyclonedx-core-java.version>
     </properties>
 
     <scm>
@@ -93,6 +93,14 @@
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.13.1</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.github.tomakehurst</groupId>
+            <artifactId>wiremock</artifactId>
+            <version>2.20.0</version>
+            <scope>test</scope>
         </dependency>
 
         <dependency>

--- a/plugins/dependency-checker/src/test/resources/bin/npm
+++ b/plugins/dependency-checker/src/test/resources/bin/npm
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-docker run --rm -v $PWD:/wrk -w /wrk node:18.16.0 npm $1
+docker run --rm -v $PWD:/wrk -w /wrk node:18.20.8 npm "$@"

--- a/plugins/dependency-checker/src/test/resources/bin/npx
+++ b/plugins/dependency-checker/src/test/resources/bin/npx
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-
-docker run --rm -v $PWD:/wrk -w /wrk node:18.16.0 npx $1

--- a/plugins/dependencytrack-publisher/README.md
+++ b/plugins/dependencytrack-publisher/README.md
@@ -2,7 +2,7 @@
 
 ### Description
 
-This plugin will takes the generated bom.xml file in previous step and publish to our internal
+This plugin takes the generated SBOM file from the previous step and publishes it to our internal
 [Dependency Track](https://dependencytrack.org/) instance.
 
 ### Configuration
@@ -26,7 +26,7 @@ sauron.plugins:
 
 - commitId: Id of the commit that is being built.
 
-- cycloneDxBomPath: Path to the bom.xml file.
+- cycloneDxBomPath: Path to the `bom.xml` or `bom.json` file.
 
 ### Output
 


### PR DESCRIPTION
Due to some problems generating the SBOM for our internal projects, we decided to try out the new `npm sbom` command instead of relying on some external dependency.